### PR TITLE
fix: regenerate feeds when episodes are deleted or published

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -381,15 +381,13 @@ func (svc *Service) PublishEpisodes(ctx context.Context, userID string, episodeI
 		slog.String("user_id", userID),
 	}
 
-	changedFeedIDs := make([]string, 0, 10)
+	changedFeedsMap := make(map[string]struct{}, len(feedIDs))
 
 	if err := svc.repository.Transaction(ctx, func(ctx context.Context) error {
 		existing, err := svc.repository.ListPublicationsByEpisodeIDs(ctx, userID, episodeIDs)
 		if err != nil {
 			return telemetry.LogError(svc.logger, ctx, err, "failed to list publicationsToCreate by episode ids")
 		}
-
-		changedFeedsMap := make(map[string]struct{}, len(feedIDs))
 
 		publicationsToDelete := make([]string, 0, len(existing))
 
@@ -437,7 +435,7 @@ func (svc *Service) PublishEpisodes(ctx context.Context, userID string, episodeI
 
 	if err := svc.jobsQueue.Publish(ctx, queueEventRegenerateFeed, RegenerateFeedQueuePayload{
 		UserID:  userID,
-		FeedIDs: changedFeedIDs,
+		FeedIDs: maps.Keys(changedFeedsMap),
 	}); err != nil {
 		return telemetry.LogError(svc.logger, ctx, err, "failed to publish regenerate feed job", fields...)
 	}
@@ -512,8 +510,10 @@ func (svc *Service) DeleteEpisodes(ctx context.Context, userID string, epIDs []s
 	}
 
 	publicationIDs := make([]string, 0, len(publications))
+	affectedFeedsMap := make(map[string]struct{})
 	for _, p := range publications {
 		publicationIDs = append(publicationIDs, p.ID)
+		affectedFeedsMap[p.FeedID] = struct{}{}
 	}
 
 	if err := svc.repository.DeletePublications(ctx, userID, publicationIDs); err != nil {
@@ -528,6 +528,15 @@ func (svc *Service) DeleteEpisodes(ctx context.Context, userID string, epIDs []s
 
 	if err := svc.repository.DeleteEpisodes(ctx, userID, epIDs); err != nil {
 		return telemetry.LogError(svc.logger, ctx, err, "failed to delete episodes", fields...)
+	}
+
+	if len(affectedFeedsMap) > 0 {
+		if err := svc.jobsQueue.Publish(ctx, queueEventRegenerateFeed, RegenerateFeedQueuePayload{
+			UserID:  userID,
+			FeedIDs: maps.Keys(affectedFeedsMap),
+		}); err != nil {
+			return telemetry.LogError(svc.logger, ctx, err, "failed to publish regenerate feed job", fields...)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Two bugs fixed:
- DeleteEpisodes: deleting episodes removed publications but never
  regenerated the affected feeds, leaving stale feed XML in S3
- PublishEpisodes: changedFeedsMap was declared inside the transaction
  closure but changedFeedIDs (used for regeneration) was a separate
  empty slice declared outside, so feed regeneration always received
  an empty list

https://claude.ai/code/session_01AanBKhUzmHUdtoKw8VbG6J